### PR TITLE
Basic exception/gcsafe annotations

### DIFF
--- a/src/nimqml/private/constructors.nim
+++ b/src/nimqml/private/constructors.nim
@@ -1,3 +1,5 @@
+{.push raises: [], gcsafe.}
+
 ############# QObject #############
 proc setup*(self: QObject) 
 proc delete*(self: QObject) =
@@ -205,3 +207,4 @@ proc new(typ: type LambdaInvoker): LambdaInvoker =
   result.lock.initLock()
   result.lambdas = initTable[int, LambdaInvokerProc]()
   
+{.pop.}

--- a/src/nimqml/private/dotherside.nim
+++ b/src/nimqml/private/dotherside.nim
@@ -1,3 +1,5 @@
+{.push raises: [].}
+
 const dynLibName =
   case system.hostOS:
     of "windows":
@@ -303,3 +305,5 @@ proc dos_qabstracttablemodel_create(modelPtr: NimQAbstractTableModel,
                                     qaimCallbacks: DosQAbstractItemModelCallbacks): DosQAbstractTableModel {.cdecl, dynlib: dynLibName, importc.}
 proc dos_qabstracttablemodel_parent(modelPtr: DosQAbstractTableModel, index: DosQModelIndex): DosQModelIndex {.cdecl, dynlib: dynLibName, importc.}
 proc dos_qabstracttablemodel_index(modelPtr: DosQAbstractTableModel, row: cint, column: cint, parent: DosQModelIndex): DosQModelIndex {.cdecl, dynlib: dynLibName, importc.}
+
+{.pop.}

--- a/src/nimqml/private/nimqmlmacros.nim
+++ b/src/nimqml/private/nimqmlmacros.nim
@@ -407,12 +407,12 @@ proc generateMetaObjectInitializer(info: QObjectInfo): NimNode {.compiletime.} =
 proc generateMetaObjectAccessors(info: QObjectInfo): NimNode {.compiletime.} =
   ## Generate the metaObject instance and accessors
   let str = """
+var $1instance {.threadvar.}: QMetaObject
 proc staticMetaObject*(c: type $1): QMetaObject =
-  var instance {.threadvar.}: QMetaObject
-  if instance.isNil():
-    instance = $1.initializeMetaObjectInstance()
+  if $1instance.isNil():
+    $1instance = $1.initializeMetaObjectInstance()
 
-  instance
+  $1instance
 
 proc staticMetaObject*(self: $1): QMetaObject = typeof(self).staticMetaObject()
 method metaObject*(self: $1): QMetaObject {.raises: [].} = typeof(self).staticMetaObject()

--- a/src/nimqml/private/qabstractitemmodel.nim
+++ b/src/nimqml/private/qabstractitemmodel.nim
@@ -1,10 +1,10 @@
+var qAbstractItemModelinstance {.threadvar.}: QMetaObject
 proc staticMetaObject*(c: type QAbstractItemModel): QMetaObject =
   ## Return the metaObject of QObject
-  var instance {.threadvar.}: QMetaObject
-  if instance.isNil():
-    instance = newQAbstractItemModelMetaObject()
+  if qAbstractItemModelinstance.isNil():
+    qAbstractItemModelinstance = newQAbstractItemModelMetaObject()
 
-  instance
+  qAbstractItemModelinstance
 
 proc staticMetaObject*(self: QAbstractItemModel): QMetaObject =
   ## Return the metaObject of QObject

--- a/src/nimqml/private/qabstractitemmodel.nim
+++ b/src/nimqml/private/qabstractitemmodel.nim
@@ -1,14 +1,16 @@
-let qAbstractItemModelStaticMetaObjectInstance = newQAbstractItemModelMetaObject()
-
 proc staticMetaObject*(c: type QAbstractItemModel): QMetaObject =
-  ## Return the metaObject of QAbstractItemModel
-  qAbstractItemModelStaticMetaObjectInstance
+  ## Return the metaObject of QObject
+  var instance {.threadvar.}: QMetaObject
+  if instance.isNil():
+    instance = newQAbstractItemModelMetaObject()
+
+  instance
 
 proc staticMetaObject*(self: QAbstractItemModel): QMetaObject =
-  ## Return the metaObject of QAbstractItemModel
-  qAbstractItemModelStaticMetaObjectInstance
+  ## Return the metaObject of QObject
+  typeof(self).staticMetaObject()
 
-method metaObject*(self: QAbstractItemModel): QMetaObject =
+method metaObject*(self: QAbstractItemModel): QMetaObject {.raises: [].} =
   # Return the metaObject
   QAbstractItemModel.staticMetaObject
 

--- a/src/nimqml/private/qabstractlistmodel.nim
+++ b/src/nimqml/private/qabstractlistmodel.nim
@@ -1,10 +1,10 @@
+var qAbstractListModelinstance {.threadvar.}: QMetaObject
 proc staticMetaObject*(c: type QAbstractListModel): QMetaObject =
   ## Return the metaObject of QObject
-  var instance {.threadvar.}: QMetaObject
-  if instance.isNil():
-    instance = newQAbstractListModelMetaObject()
+  if qAbstractListModelinstance.isNil():
+    qAbstractListModelinstance = newQAbstractListModelMetaObject()
 
-  instance
+  qAbstractListModelinstance
 
 proc staticMetaObject*(self: QAbstractListModel): QMetaObject =
   ## Return the metaObject of QObject

--- a/src/nimqml/private/qabstractlistmodel.nim
+++ b/src/nimqml/private/qabstractlistmodel.nim
@@ -1,14 +1,16 @@
-let qAbstractListModelStaticMetaObjectInstance = newQAbstractListModelMetaObject()
-
 proc staticMetaObject*(c: type QAbstractListModel): QMetaObject =
-  ## Return the metaObject of QAbstractListModel
-  qAbstractListModelStaticMetaObjectInstance
+  ## Return the metaObject of QObject
+  var instance {.threadvar.}: QMetaObject
+  if instance.isNil():
+    instance = newQAbstractListModelMetaObject()
+
+  instance
 
 proc staticMetaObject*(self: QAbstractListModel): QMetaObject =
-  ## Return the metaObject of QAbstractListModel
-  qAbstractListModelStaticMetaObjectInstance
+  ## Return the metaObject of QObject
+  typeof(self).staticMetaObject()
 
-method metaObject*(self: QAbstractListModel): QMetaObject =
+method metaObject*(self: QAbstractListModel): QMetaObject {.raises: [].} =
   # Return the metaObject
   QAbstractListModel.staticMetaObject
 

--- a/src/nimqml/private/qabstracttablemodel.nim
+++ b/src/nimqml/private/qabstracttablemodel.nim
@@ -1,10 +1,10 @@
+var qAbstractTableModelinstance {.threadvar.}: QMetaObject
 proc staticMetaObject*(c: type QAbstractTableModel): QMetaObject =
   ## Return the metaObject of QObject
-  var instance {.threadvar.}: QMetaObject
-  if instance.isNil():
-    instance = newQAbstractTableModelMetaObject()
+  if qAbstractTableModelinstance.isNil():
+    qAbstractTableModelinstance = newQAbstractTableModelMetaObject()
 
-  instance
+  qAbstractTableModelinstance
 
 proc staticMetaObject*(self: QAbstractTableModel): QMetaObject =
   ## Return the metaObject of QObject

--- a/src/nimqml/private/qabstracttablemodel.nim
+++ b/src/nimqml/private/qabstracttablemodel.nim
@@ -1,14 +1,16 @@
-let qAbstractTableModelStaticMetaObjectInstance = newQAbstractTableModelMetaObject()
-
 proc staticMetaObject*(c: type QAbstractTableModel): QMetaObject =
-  ## Return the metaObject of QAbstractTableModel
-  qAbstractTableModelStaticMetaObjectInstance
+  ## Return the metaObject of QObject
+  var instance {.threadvar.}: QMetaObject
+  if instance.isNil():
+    instance = newQAbstractTableModelMetaObject()
+
+  instance
 
 proc staticMetaObject*(self: QAbstractTableModel): QMetaObject =
-  ## Return the metaObject of QAbstractTableModel
-  qAbstractTableModelStaticMetaObjectInstance
+  ## Return the metaObject of QObject
+  typeof(self).staticMetaObject()
 
-method metaObject*(self: QAbstractTableModel): QMetaObject =
+method metaObject*(self: QAbstractTableModel): QMetaObject {.raises: [].} =
   # Return the metaObject
   QAbstractTableModel.staticMetaObject
 

--- a/src/nimqml/private/qmodelindex.nim
+++ b/src/nimqml/private/qmodelindex.nim
@@ -8,7 +8,7 @@ proc setup(self: QModelIndex, other: DosQModelIndex, takeOwnership: Ownership) =
 
 proc delete*(self: QModelIndex) =
   ## Delete the given QModelIndex
-  if not self.vptr.isNil:
+  if self.vptr.isNil:
     return
   debugMsg("QModelIndex", "delete")
   dos_qmodelindex_delete(self.vptr)

--- a/src/nimqml/private/qobject.nim
+++ b/src/nimqml/private/qobject.nim
@@ -1,10 +1,10 @@
+var qObjectinstance {.threadvar.}: QMetaObject
 proc staticMetaObject*(c: type QObject): QMetaObject =
   ## Return the metaObject of QObject
-  var instance {.threadvar.}: QMetaObject
-  if instance.isNil():
-    instance = newQObjectMetaObject()
+  if qObjectinstance.isNil():
+    qObjectinstance = newQObjectMetaObject()
 
-  instance
+  qObjectinstance
 
 proc staticMetaObject*(self: QObject): QMetaObject =
   ## Return the metaObject of QObject

--- a/src/nimqml/private/qobject.nim
+++ b/src/nimqml/private/qobject.nim
@@ -1,12 +1,14 @@
-let qObjectStaticMetaObjectInstance = newQObjectMetaObject()
-
 proc staticMetaObject*(c: type QObject): QMetaObject =
   ## Return the metaObject of QObject
-  qObjectStaticMetaObjectInstance
+  var instance {.threadvar.}: QMetaObject
+  if instance.isNil():
+    instance = newQObjectMetaObject()
+
+  instance
 
 proc staticMetaObject*(self: QObject): QMetaObject =
   ## Return the metaObject of QObject
-  qObjectStaticMetaObjectInstance
+  typeof(self).staticMetaObject()
 
 proc objectName*(self: QObject): string =
   ## Return the QObject name
@@ -22,7 +24,7 @@ proc `objectName=`*(self: QObject, name: string) =
   ## Sets the Qobject name
   self.setObjectName(name)
 
-method metaObject*(self: QObject): QMetaObject {.base.} =
+method metaObject*(self: QObject): QMetaObject {.base, gcsafe, raises: [].} =
   ## Return the metaObject
   QObject.staticMetaObject
 


### PR DESCRIPTION
Both forward declarations and methods are assumed not gcsafe and raising `Exception` unless otherwise specified.

This PR is a first pass over the API to ensure that it does not leak unwanted `raises`/not-`gcsafe` effects into the application using `nimqml` from the bulk of its API.

The changes do not touch the "public" QAIM methods but aims to fix at least the internals. Of course, raising from within a QAIM callback would crash the application but applying strict `raises: []` would be a (significantly) breaking change since user code would now have to be raises-correct.

* `c` functions do not raise exception (`importc` implies `gcsafe` but not `raises:[]`.}
* `metaObject` instances are not suitable to expose as a global since it's a ref type (accessing it from different threads is not gcsafe) - this PR switches to a lazy threadvar instead

Free bonus: leak fix in QModelIndex